### PR TITLE
Load Ode.txt as classpath resource

### DIFF
--- a/Java8Functional/practical/after/filesearch/FileSearch.java
+++ b/Java8Functional/practical/after/filesearch/FileSearch.java
@@ -1,10 +1,9 @@
 package filesearch;
 
 import java.io.BufferedReader;
+import java.io.InputStreamReader;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.function.Function;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -16,13 +15,13 @@ public class FileSearch {
 	
 	/**
 	 * Count the number of words that match supplied word in supplied file
-	 * @param file			file to process
+	 * @param file		file to process (loaded as resource)
 	 * @param wordToMatch	word to look for
 	 * @return				number of matches
 	 */
 	public int countInstances(String file, String wordToMatch){
-		try (BufferedReader reader = Files.newBufferedReader(
-		        Paths.get(file), StandardCharsets.UTF_8)) {
+		try (BufferedReader reader = new BufferedReader(new InputStreamReader(
+			getClass().getResourceAsStream(file), StandardCharsets.UTF_8))) {
 			final Pattern wordMatcher = Pattern.compile(WORD_REGEXP);
 			return (int) reader.lines()
 					.flatMap(wordMatcher::splitAsStream)
@@ -37,12 +36,12 @@ public class FileSearch {
 
 	/**
 	 * Count the number of words in supplied file
-	 * @param file	file to process
-	 * @return		total number of words
+	 * @param file	file to process (loaded as resource)
+	 * @return	total number of words
 	 */
 	public int countWords(String file){
-		try (BufferedReader reader = Files.newBufferedReader(
-		        Paths.get(file), StandardCharsets.UTF_8)) {
+		try (BufferedReader reader = new BufferedReader(new InputStreamReader(
+			getClass().getResourceAsStream(file), StandardCharsets.UTF_8))) {
 			final Pattern wordMatcher = Pattern.compile(WORD_REGEXP);
 			return (int) reader.lines()
 					.flatMap(wordMatcher::splitAsStream)
@@ -57,8 +56,8 @@ public class FileSearch {
 	/**
 	 * Count the number of different words in supplied file
 	 * uses case-insensitive match.
-	 * @param file	file to process
-	 * @return		total number of different words
+	 * @param file	file to process (loaded as resource)
+	 * @return	total number of different words
 	 */
 	public int countDistinctWords(String file){
 		return process(file, 
@@ -71,8 +70,8 @@ public class FileSearch {
 	/**
 	 * Count the number of letters in the longest word in supplied file
 	 * uses case-insensitive match.
-	 * @param file	file to process
-	 * @return		length of longest word
+	 * @param file	file to process (loaded as resource)
+	 * @return	length of longest word
 	 */	
 	public int longestWordLength(String file){
 		return process(file, 
@@ -84,8 +83,8 @@ public class FileSearch {
 	//This method can be used to shorten the methods above, by extracting the repeating
 	//behaviour, and taking in a function to deal with the specialised behaviour
 	private int process(String file, Function<Stream<String>, Integer>wordProcessor ){
-		try (BufferedReader reader = Files.newBufferedReader(
-		        Paths.get(file), StandardCharsets.UTF_8)) {
+		try (BufferedReader reader = new BufferedReader(new InputStreamReader(
+			getClass().getResourceAsStream(file), StandardCharsets.UTF_8))) {
 			final Pattern wordMatcher = Pattern.compile(WORD_REGEXP);
 			return wordProcessor.apply( reader.lines()
 					.flatMap(wordMatcher::splitAsStream));

--- a/Java8Functional/practical/before/filesearch/FileSearch.java
+++ b/Java8Functional/practical/before/filesearch/FileSearch.java
@@ -1,10 +1,9 @@
 package filesearch;
 
 import java.io.BufferedReader;
+import java.io.InputStreamReader;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.regex.Pattern;
@@ -15,15 +14,15 @@ public class FileSearch {
 	
 	/**
 	 * Count the number of words that match supplied word in supplied file
-	 * @param file			file to process
+	 * @param file			file to process (loaded as resource)
 	 * @param wordToMatch	word to look for
 	 * @return				number of matches
 	 */
 	public int countInstances(String file, String wordToMatch){
 		int count = 0;
 		final Pattern wordMatcher = Pattern.compile(WORD_REGEXP);
-		try (BufferedReader reader = Files.newBufferedReader(
-		        Paths.get(file), StandardCharsets.UTF_8)) {
+		try (BufferedReader reader = new BufferedReader(new InputStreamReader(
+			getClass().getResourceAsStream(file), StandardCharsets.UTF_8))) {
 			String line = reader.readLine();
 			while (line != null){
 				String[] words = wordMatcher.split(line);
@@ -43,14 +42,14 @@ public class FileSearch {
 	
 	/**
 	 * Count the number of words in supplied file
-	 * @param file	file to process
+	 * @param file	file to process (loaded as resource)
 	 * @return		total number of words
 	 */
 	public int countWords(String file){
 		int count = 0;
 		final Pattern wordMatcher = Pattern.compile(WORD_REGEXP);
-		try (BufferedReader reader = Files.newBufferedReader(
-		        Paths.get(file), StandardCharsets.UTF_8)) {
+		try (BufferedReader reader = new BufferedReader(new InputStreamReader(
+			getClass().getResourceAsStream(file), StandardCharsets.UTF_8))) {
 			String line = reader.readLine();
 			while (line != null){
 				String[] words = wordMatcher.split(line);
@@ -72,14 +71,14 @@ public class FileSearch {
 	/**
 	 * Count the number of different words in supplied file
 	 * uses case-insensitive match.
-	 * @param file	file to process
+	 * @param file	file to process (loaded as resource)
 	 * @return		total number of different words
 	 */
 	public int countDistinctWords(String file){
 		int count = 0;
 		final Pattern wordMatcher = Pattern.compile(WORD_REGEXP);
-		try (BufferedReader reader = Files.newBufferedReader(
-		        Paths.get(file), StandardCharsets.UTF_8)) {
+		try (BufferedReader reader = new BufferedReader(new InputStreamReader(
+			getClass().getResourceAsStream(file), StandardCharsets.UTF_8))) {
 			Set<String> distinctWords = new HashSet<>();
 			String line = reader.readLine();
 			while (line != null){
@@ -103,14 +102,14 @@ public class FileSearch {
 	/**
 	 * Count the number of letters in the longest word in supplied file
 	 * uses case-insensitive match.
-	 * @param file	file to process
+	 * @param file	file to process (loaded as resource)
 	 * @return		length of longest word
 	 */
 	public int longestWordLength(String file){
 		int maxLength = 0;
 		final Pattern wordMatcher = Pattern.compile(WORD_REGEXP);
-		try (BufferedReader reader = Files.newBufferedReader(
-		        Paths.get(file), StandardCharsets.UTF_8)) {
+		try (BufferedReader reader = new BufferedReader(new InputStreamReader(
+			getClass().getResourceAsStream(file), StandardCharsets.UTF_8))) {
 			String line = reader.readLine();
 			while (line != null){
 				String[] words = wordMatcher.split(line);


### PR DESCRIPTION
During the session there seemed to be a few people (myself included) who had a bit of a problem getting started because of the path to the `Ode.txt` file in the filesearch example. Loading the file from the classpath as a resource should reduce these issues, as the file is effectively loaded relative from the source file. This means that the code should run whatever directory you have as the current directory when starting the process (which may depend on how you import the project into your IDE), allowing you to get straight to the interesting part of using the functional techniques.

This PR relies on the IDE copying non `.java` files from the source directory to the build directory during the build, which is the default on at least Eclipse and (I think) Jetbrains.

One minor downside with this is that you can’t use [`Files.lines`](https://docs.oracle.com/javase/8/docs/api/java/nio/file/Files.html#lines-java.nio.file.Path-java.nio.charset.Charset-) to get a `Stream` directly from the file name without creating a `BufferedReader`, but the “after” example does’t use this method either.
